### PR TITLE
Add case for vscode-oss (Solus)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -15,10 +15,21 @@ let FILES = true;
 let vscodeSearchProvider = null;
 let storage = null;
 
+let configDirName = "Code";
+let commandName = "code";
+
 let desktopAppInfo = Gio.DesktopAppInfo.new("code.desktop");
 
 if (desktopAppInfo === null) {
   desktopAppInfo = Gio.DesktopAppInfo.new("visual-studio-code.desktop");
+}
+
+if (desktopAppInfo === null) {
+  desktopAppInfo = Gio.DesktopAppInfo.new("vscode-oss.desktop");
+  if (desktopAppInfo !== null) {
+    configDir = "Code - OSS";
+    commandName = "code-oss";
+  }
 }
 
 let vscodeIcon;
@@ -129,12 +140,12 @@ const VSCodeSearchProvider = new Lang.Class({
     const result = this._results.filter(function(res) {
       return res.id === id;
     })[0];
-    Util.spawn(["code", result.path]);
+    Util.spawn([commandName, result.path]);
   }
 });
 
 function init() {
-  storage = homePath + "/.config/Code/storage.json";
+  storage = homePath + "/.config/" + configDirName + "/storage.json";
 }
 
 function enable() {

--- a/extension.js
+++ b/extension.js
@@ -27,7 +27,7 @@ if (desktopAppInfo === null) {
 if (desktopAppInfo === null) {
   desktopAppInfo = Gio.DesktopAppInfo.new("vscode-oss.desktop");
   if (desktopAppInfo !== null) {
-    configDir = "Code - OSS";
+    configDirName = "Code - OSS";
     commandName = "code-oss";
   }
 }


### PR DESCRIPTION
(Naively) detect OSS version based on .desktop file,  use different config dir and command name if OSS version detected.
 
Fixes #9 