### PR TITLE
Add support for vscode snap

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,6 +25,14 @@ if (desktopAppInfo === null) {
 }
 
 if (desktopAppInfo === null) {
+  desktopAppInfo = Gio.DesktopAppInfo.new("vscode_vscode.desktop");
+}
+
+if (desktopAppInfo === null) {
+  desktopAppInfo = Gio.DesktopAppInfo.new("code_code.desktop");
+}
+
+if (desktopAppInfo === null) {
   desktopAppInfo = Gio.DesktopAppInfo.new("vscode-oss.desktop");
   if (desktopAppInfo !== null) {
     configDirName = "Code - OSS";


### PR DESCRIPTION
Snap version of vscode has `vscode_vscode.desktop` as desktop id, while microsoft should inherit it soon as `code_code.desktop`

See https://snapcraft.io/vscode