### PR TITLE
fix when workspace identifier exists

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -50,12 +50,21 @@ function debug(message) {
   global.log("VS Code Search Provider ~ " + message);		
 }
 
+function isString(value) {
+  return typeof value === 'string' || value instanceof String;
+}
+
 function getPaths() {
   function toPath(uri) {
-    if (uri.indexOf('file://') === 0) {
-      return uri.substring(7);
+    if (isString(uri)) {
+      if (uri.indexOf('file://') === 0) {
+        return uri.substring(7);
+      }
+      return uri;
     }
-    return uri;
+    else {
+      return uri.configPath;
+    }
   }
 
   function exists(path) {


### PR DESCRIPTION
Recent workspace file history contains strings or workspace identifier objects: https://github.com/Microsoft/vscode/blob/27797381c52aba1d5afb0c5004b22472dc672520/src/vs/platform/history/electron-main/historyMainService.ts#L269