### PR TITLE
Use correct executable for launch from gui

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,6 @@ let vscodeSearchProvider = null;
 let storage = null;
 
 let configDirName = "Code";
-let commandName = "code";
 
 let desktopAppInfo = Gio.DesktopAppInfo.new("code.desktop");
 
@@ -36,14 +35,15 @@ if (desktopAppInfo === null) {
   desktopAppInfo = Gio.DesktopAppInfo.new("vscode-oss.desktop");
   if (desktopAppInfo !== null) {
     configDirName = "Code - OSS";
-    commandName = "code-oss";
   }
 }
 
 let vscodeIcon;
+let commandName = "code";
 
 if (desktopAppInfo !== null) {
   vscodeIcon = desktopAppInfo.get_icon();
+  commandName = desktopAppInfo.get_commandline().split(' ')[0];
 }
 
 function debug(message) {		

--- a/extension.js
+++ b/extension.js
@@ -51,6 +51,13 @@ function debug(message) {
 }
 
 function getPaths() {
+  function toPath(uri) {
+    if (uri.indexOf('file://') === 0) {
+      return uri.substring(7);
+    }
+    return uri;
+  }
+
   function exists(path) {
     return Gio.File.new_for_path(path).query_exists(null);
   }
@@ -60,15 +67,15 @@ function getPaths() {
     
     let workspaces = [];
     if (WORKSPACES) {
-      workspaces = json.openedPathsList.workspaces;
+      workspaces = json.openedPathsList.workspaces2 || json.openedPathsList.workspaces || [];
     }
 
     let files = [];
     if (FILES) {
-      files = json.openedPathsList.files;
+      files = json.openedPathsList.files2 || json.openedPathsList.files || [];
     }
 
-    return workspaces.concat(files).filter(exists);
+    return workspaces.concat(files).map(toPath).filter(exists);
   } catch (e) {
     return [];
   }


### PR DESCRIPTION
Fixes problems with missing environment variables like ${env:NVM_BIN}.

In my case it uses `/usr/share/code/code` instead of `/usr/bin/code`.

I couldn't check if this works with flatpak. It should work with all other install versions though. I think the extension could not work with flatpak anyways as `code` would not be a valid command anyways.