### PR TITLE
Use desktop app info and some other improvements

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,3 +1,4 @@
+const ByteArray = imports.byteArray;
 const Lang = imports.lang;
 const Main = imports.ui.main;
 const GLib = imports.gi.GLib;
@@ -65,7 +66,7 @@ function getPaths() {
   }
 
   try {
-    const json = JSON.parse(GLib.file_get_contents(storage)[1]);
+    const json = JSON.parse(ByteArray.toString(GLib.file_get_contents(storage)[1]));
 
     let workspaces = [];
     if (WORKSPACES) {

--- a/extension.js
+++ b/extension.js
@@ -168,18 +168,28 @@ const VSCodeSearchProvider = new Lang.Class({
     const result = this._results.filter(function (res) {
       return res.id === id;
     })[0];
-    if (desktopAppInfo !== null) {
-      try {
-        desktopAppInfo.launch([Gio.File.new_for_path(result.path)]);
-      } catch (err) {
-        Main.notifyError('Failed to launch Code', err.message);
-      }
-    } else {
-      // If we have no desktop app, fall back to the code binary
-      Util.spawn(["code", result.path]);
-    }
-  }
+    launchVSCode(result.path);
+  },
+
+  launchSearch: function () {
+    launchVSCode();
+  },
 });
+
+function launchVSCode(path) {
+  if (desktopAppInfo !== null) {
+    try {
+      const files = path ? [Gio.File.new_for_path(path)] : [];
+      desktopAppInfo.launch(files);
+    } catch (err) {
+      Main.notifyError('Failed to launch Code', err.message);
+    }
+  } else {
+    // If we have no desktop app, fall back to the code binary
+    const command = path ? ["code", path] : [code];
+    Util.spawn(command);
+  }
+}
 
 function init() {
   storage = homePath + "/.config/" + configDirName + "/storage.json";

--- a/extension.js
+++ b/extension.js
@@ -180,7 +180,7 @@ function launchVSCode(path) {
   if (desktopAppInfo !== null) {
     try {
       const files = path ? [Gio.File.new_for_path(path)] : [];
-      desktopAppInfo.launch(files);
+      desktopAppInfo.launch(files, null);
     } catch (err) {
       Main.notifyError('Failed to launch Code', err.message);
     }

--- a/extension.js
+++ b/extension.js
@@ -94,9 +94,9 @@ function fullPath(path) {
     : path;
 }
 
-function pathToResultObject(path, index) {
+function pathToResultObject(path) {
   return {
-    id: index + 1,
+    id: `vscode-${fullPath(path)}`,
     name: projectNameFromPath(path),
     description: fullPath(path),
     path: path,

--- a/schemas/org.gnome.shell.extensions.vscode-search-provider.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.vscode-search-provider.gschema.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 
 <schemalist gettext-domain="gnome-shell-extensions">
-  <schema id="org.gnome.shell.extensions.vscode-search-provider"
-      path="/org/gnome/shell/extensions/vscode-search-provider/">
+  <schema id="org.gnome.shell.extensions.vscode-search-provider" path="/org/gnome/shell/extensions/vscode-search-provider/">
 
     <key name="show-workspaces" type="b">
       <default>true</default>
@@ -17,7 +16,7 @@
     </key>
 
     <key name="search-prefix" type="s">
-      <default>code:</default>
+      <default>"code:"</default>
       <summary>Search prefix</summary>
       <description>Search prefix used to limit results to VSCode search provider</description>
     </key>


### PR DESCRIPTION
* Use the desktop app info (if any exists) as app info of the search provider, so that it actually looks as if the results came straight from VSCode.
* Use the desktop app info to launch code when selecting a result.  I'm not sure about the differences to just invoking code, but it works even if `code` is not in `$PATH`, and it looks like the right thing to do, and perhaps integrates better in gnome shell.
* Implement `launchSearch` which gets called when you click on the search provider name itself instead of a result.  It now launches VSCode without any specific workspace, and thus gives you a quick way to get a new Code window if you didn't find the workspace you were looking for.
* Fix the default value for `prefix`.  When I tried to test the extension `gnome-extensions pack` failed, because `glib-compile-schemas` failed with the following error:

    ```
    lib-compile-schemas --strict schemas/
    schemas/org.gnome.shell.extensions.vscode-search-provider.gschema.xml:21:1  Failed to parse <default> value of type “s”: 0-4:unknown keyword.  --strict was specified; exiting.
    ```

    It looks as if you need to put the default value for `s` things in quotes, see e.g. <https://rm5248.com/gsettings/>, so I did just that.  I don't know what this changes, but it makes `gnome-extensions pack` work :)
* Use `ByteArray.toString` to fix the following deprecation warning in logs:

    > Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array)

* Use the path of each result plus a `vscode` prefix as ID of a result, to make the ID truly unique across all possible results.  

    Background is that Gnome shell apparently doesn't keep track of which ID comes from which provider, and passes every ID to every Javascript search provider—at least I see IDs from this provider being given to a provider I wrote.  To make debugging easier (undefined property 1 isn't really helpful :innocent: ) and—more important—to avoid that another provider which also uses the array index as ID—accidentally reports wrong meta info create a truly unique ID instead of using the array index.