### PR TITLE
Add content to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # vscode-search-provider
 
 GNOME Search Provider for recent VS Code projects.
+
+## Requirements
+
+- Gnome shell 3.34 or newer.
+
+## Installation
+
+Visit [Releases] and download `vscode-search-provider@jomik.org.shell-extension.zip`
+from the latest release, then run
+
+```console
+$ gnome-extensions install vscode-search-provider@jomik.org.shell-extension.zip
+```
+
+Alternative you can install directly from [Gnome Extensions][gexts] but the
+mandatory review process sometimes delays new releases for a couple of days.
+
+[Releases]: https://github.com/Jomik/vscode-search-provider/releases
+[gexts]: https://extensions.gnome.org/extension/1207/vscode-search-provider/


### PR DESCRIPTION
I added a bit of content to the README, most notably some installation instructions.

I'd also like to set the URL of this Github repo to the Gnome Extensions URL to link the two, but I lack the rights to do so.