### PR TITLE
Support workspace item objects

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -329,6 +329,22 @@ const createRecentItem = (kind: RecentItemKind) => (
 };
 
 /**
+ * Convert any workspace item objects to URIs.
+ *
+ * @param item The workspace item from storage.json
+ * @returns The URI for the workspace
+ */
+const workspaceItemToUri = (
+  item: string | { configURIPath: string }
+): string => {
+  if (typeof item === "object" && "configURIPath" in item) {
+    return item.configURIPath;
+  } else {
+    return item;
+  }
+};
+
+/**
  * Find recent items from VSCode.
  *
  * @param configDirectoryName The name of the config directory of the code app
@@ -346,11 +362,14 @@ const findVSCodeRecentItems = (
 
     const storage = JSON.parse(ByteArray.toString(contents));
 
-    const recentWorkspaceURIs: string[] =
+    const recentWorkspaceItems: (string | { configURIPath: string })[] =
       storage.openedPathsList.workspaces3 ||
       storage.openedPathsList.workspaces2 ||
       storage.openedPathsList.workspaces ||
       [];
+
+    const recentWorkspaceURIs = recentWorkspaceItems.map(workspaceItemToUri);
+
     const recentFileURIs: string[] =
       storage.openedPathsList.files2 || storage.openedPathsList.files || [];
 

--- a/extension.ts
+++ b/extension.ts
@@ -328,15 +328,19 @@ const createRecentItem = (kind: RecentItemKind) => (
   };
 };
 
+interface MultiRootWorkspaceItem {
+  readonly configURIPath: string;
+}
+
+type WorkspaceItem = string | MultiRootWorkspaceItem;
+
 /**
  * Convert any workspace item objects to URIs.
  *
  * @param item The workspace item from storage.json
  * @returns The URI for the workspace
  */
-const workspaceItemToUri = (
-  item: string | { configURIPath: string }
-): string => {
+const workspaceItemToUri = (item: WorkspaceItem): string => {
   if (typeof item === "object" && "configURIPath" in item) {
     return item.configURIPath;
   } else {
@@ -362,15 +366,17 @@ const findVSCodeRecentItems = (
 
     const storage = JSON.parse(ByteArray.toString(contents));
 
-    const recentWorkspaceItems: (string | { configURIPath: string })[] =
+    const recentWorkspaceItems: ReadonlyArray<WorkspaceItem> =
       storage.openedPathsList.workspaces3 ||
       storage.openedPathsList.workspaces2 ||
       storage.openedPathsList.workspaces ||
       [];
 
-    const recentWorkspaceURIs = recentWorkspaceItems.map(workspaceItemToUri);
+    const recentWorkspaceURIs: ReadonlyArray<string> = recentWorkspaceItems.map(
+      workspaceItemToUri
+    );
 
-    const recentFileURIs: string[] =
+    const recentFileURIs: ReadonlyArray<string> =
       storage.openedPathsList.files2 || storage.openedPathsList.files || [];
 
     const recentItems = recentWorkspaceURIs


### PR DESCRIPTION
If you save a workspace to a file in code, you get an entry in storage.json that looks like this:
```json
{
  "id": "96dbbc637b1f65ded0fc02433f1e9091",
  "configURIPath": "file:///home/user/some-path/workspace-name.code-workspace"
}
```
Currently, the extension fails silently when calling `Gio.File.new_for_uri` on something that is not a URI. I was not able to make it throw an exception, it just stopped working.

This PR checks for this case and transforms the object to the string in `configUriPath` before creating the recent item.