### PR TITLE
Case insensitive search

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -162,9 +162,18 @@ const lookupRecentItems = (
 const recentItemMatchesTerms = (
   item: RecentItem,
   terms: ReadonlyArray<string> | null
-): boolean =>
-  terms !== null &&
-  terms.every((t) => item.name.includes(t) || item.readablePath.includes(t));
+): boolean => {
+  if (!terms) {
+    return false;
+  } else {
+    const lowerName = item.name.toLowerCase();
+    const lowerReadablePath = item.readablePath.toLowerCase();
+    return terms.every((term) => {
+      const lowerTerm = term.toLowerCase();
+      return lowerName.includes(lowerTerm) || lowerReadablePath.includes(lowerTerm);
+    });
+  }
+}
 
 /**
  * Find all items which match all of the given terms and have a kind contained in `kinds`.

--- a/extension.ts
+++ b/extension.ts
@@ -170,10 +170,12 @@ const recentItemMatchesTerms = (
     const lowerReadablePath = item.readablePath.toLowerCase();
     return terms.every((term) => {
       const lowerTerm = term.toLowerCase();
-      return lowerName.includes(lowerTerm) || lowerReadablePath.includes(lowerTerm);
+      return (
+        lowerName.includes(lowerTerm) || lowerReadablePath.includes(lowerTerm)
+      );
     });
   }
-}
+};
 
 /**
  * Find all items which match all of the given terms and have a kind contained in `kinds`.


### PR DESCRIPTION
This makes searches ignore case like the dashboard usually does.

Honestly, my workspaces are all lower-case, but my customers are sadly not wired that way.